### PR TITLE
Use a temp file when downloading zip to avoid big RAM usage

### DIFF
--- a/fetchup_test.go
+++ b/fetchup_test.go
@@ -47,12 +47,7 @@ func TestZip(t *testing.T) {
 	g.E(fu.Download(u))
 	g.Eq(g.Read(filepath.Join(d, "to", "file.txt")).Bytes(), data)
 	g.Eq(logger.buf, g.Render(`Download: {{.U}}
-Progress: 02%
-Progress: 05%
-Progress: 10%
 Progress: 19%
-Progress: 40%
-Progress: 80%
 Unzip: {{.D}}
 Progress: 99%
 Progress: 100%


### PR DESCRIPTION
Using a temp file avoids having to load the whole zip file in a buffer in RAM.

I'm not sure why, but loading the file in RAM takes much more RAM than the size of the file itself: I tried running go-rod on a RaspberryPi with 512 MiB of RAM (of which at least 400 were free) and while the chromium-headless zip file is only 168 MiB, it would OOM every time. Even with 512 MiB of swap, it took ages and ended being killed too.

This RAM issue was reported previously on go-rod: https://github.com/go-rod/rod/issues/1122

With this PR, the RAM usage when downloading and unzipping the file was only about 15-20 MiB so everything went fine on my RPi.